### PR TITLE
Fix transliteration order for user input

### DIFF
--- a/reg.php
+++ b/reg.php
@@ -7,7 +7,8 @@
                 "l", "d", "j", "e", "ya", "s", "m", "i", "t", "b", "Yo", "Iy", "Yu", "CH", "", "SH", "C", "U", "K", "E", "N", "G", "SH", "Z",
                 "H", "'", "F", "Y", "V", "A", "P", "R", "O", "L", "D", "J", "E", "YA", "S", "M", "I", "T", "B", "_", "X", "_", "", "", "No", ".", "", "", "", "", '', '', '\'');
 
-                $string = str_replace($eng, $rus, $string);
+                // Replace Russian characters with their transliterated Latin equivalents
+                $string = str_replace($rus, $eng, $string);
                 if (!empty($string)) {
                     return $string;
                 }


### PR DESCRIPTION
## Summary
- Correct transliteration to replace Russian characters with Latin equivalents
- Document character replacement for clarity

## Testing
- `php -l reg.php`
- `php -r 'ob_start(); include "reg.php"; ob_end_clean(); echo translit("тест");'`


------
https://chatgpt.com/codex/tasks/task_e_6895a4fd338883279247a952dea04f9e